### PR TITLE
Fix version up script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: increment chrome extnsion manifest.json version
         run: |
           CURRENT_VERSION=$(jq -r '.version' public/manifest.json)
-          NEW_VERSION=$(echo $CURRENT_VERSION | awk -F. '{$NF+=1; OFS="."; print $0}')
+          NEW_VERSION=$(echo $CURRENT_VERSION | awk -F. '{if (NF==1) {$1+=1} else {$NF+=1}; OFS="."; print $0}' | sed 's/ /./g')
           jq --arg new_version $NEW_VERSION '.version = $new_version' public/manifest.json > public/manifest.json.tmp
           mv public/manifest.json.tmp public/manifest.json
       - uses: Songmu/tagpr@v1

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Web Distiller AI",
-  "version": "0 5",
+  "version": "0.7",
   "description": "Summarizes and Translates web pages using Gemini Nano in Chrome",
   "permissions": [
     "activeTab",


### PR DESCRIPTION
This pull request fixes the version up script by updating the logic to correctly increment the version number in the manifest.json file. Previously, the script was not handling cases where the version number had multiple digits correctly. Now, the script correctly increments the version number by one, ensuring that the manifest.json file reflects the updated version.